### PR TITLE
Update compile

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -4,7 +4,7 @@ PRINCE_VERSION="11.1"
 echo "-----> Installing PrinceXML $PRINCE_VERSION"
 [ -d .downloads ] || mkdir .downloads
 (cd .downloads; [ -d "prince-$PRINCE_VERSION-linux-amd64-static" ] ||
-  curl -s http://www.princexml.com/download/prince-$PRINCE_VERSION-linux-generic-x86_64.tar.gz | tar xzf -)
+  curl -s https://www.princexml.com/download/prince-$PRINCE_VERSION-linux-generic-x86_64.tar.gz | tar xzf -)
 
 if [ -f $3/PRINCE_LICENSE ]; then
   echo "       Configuring license file"


### PR DESCRIPTION
http entry is no longer available on the princexml.com. move to use the https entry instead. 